### PR TITLE
Update packages and the target environment for test projects.

### DIFF
--- a/build/azDevOps/packages-amido-stacks-core.yml
+++ b/build/azDevOps/packages-amido-stacks-core.yml
@@ -123,4 +123,4 @@ stages:
               # Secret Config
               cosmosdb_secret: false
               # .NET Core version variables
-              dotnet_core_version: "3.1.x"
+              dotnet_core_version: "6.0.x"

--- a/build/azDevOps/packages-amido-stacks-core.yml
+++ b/build/azDevOps/packages-amido-stacks-core.yml
@@ -66,7 +66,7 @@ resources:
   repositories:
     - repository: templates
       type: github
-      name: amido/stacks-pipeline-templates
+      name: Ensono/stacks-pipeline-templates
       ref: refs/tags/v2.0.1
       # Created when you set up the connection to GitHub from Azure DevOps
       endpoint: amidostacks
@@ -81,7 +81,7 @@ stages:
     jobs:
       - job: Validation
         pool:
-          vmImage: "ubuntu-18.04"
+          vmImage: "ubuntu-22.04"
         steps:
           - checkout: self
 

--- a/build/azDevOps/packages-amido-stacks-core.yml
+++ b/build/azDevOps/packages-amido-stacks-core.yml
@@ -30,7 +30,7 @@ variables:
     value: "$(self_pipeline_repo)/scripts"
   # Path specific for this package, change accordingly
   - name: Package.Feed
-    value: "Stacks"
+    value: ""
   - name: Package.Public
     value: true
   # - name: Package.nuget_service_connection

--- a/build/azDevOps/packages-amido-stacks-core.yml
+++ b/build/azDevOps/packages-amido-stacks-core.yml
@@ -67,7 +67,7 @@ resources:
     - repository: templates
       type: github
       name: Ensono/stacks-pipeline-templates
-      ref: refs/tags/v2.0.1
+      ref: refs/heads/feature/cycle4
       # Created when you set up the connection to GitHub from Azure DevOps
       endpoint: amidostacks
   containers:

--- a/build/azDevOps/packages-amido-stacks-core.yml
+++ b/build/azDevOps/packages-amido-stacks-core.yml
@@ -33,7 +33,7 @@ variables:
     value: "Stacks"
   - name: Package.Public
     value: true
-  #- name: Package.nuget_service_connection
+  # - name: Package.nuget_service_connection
   #  value: NuGetAmidoStacksServiceConnection
   - name: Package.Path
     value: "src/Amido.Stacks.Core"

--- a/build/azDevOps/packages-amido-stacks-core.yml
+++ b/build/azDevOps/packages-amido-stacks-core.yml
@@ -119,7 +119,7 @@ stages:
               publish_public: "$(Package.Public)"
               # Nuget
               # nuget_service_connection: "$(Package.nuget_service_connection)"
-              nuget_service_connection: false
+              use_nuget_service_connection: false
               # Secret Config
               cosmosdb_secret: false
               # .NET Core version variables

--- a/build/azDevOps/packages-amido-stacks-core.yml
+++ b/build/azDevOps/packages-amido-stacks-core.yml
@@ -33,8 +33,8 @@ variables:
     value: "Stacks"
   - name: Package.Public
     value: true
-  - name: Package.nuget_service_connection
-    value: NuGetAmidoStacksServiceConnection
+  #- name: Package.nuget_service_connection
+  #  value: NuGetAmidoStacksServiceConnection
   - name: Package.Path
     value: "src/Amido.Stacks.Core"
   - name: Test.Path
@@ -117,7 +117,9 @@ stages:
               package_feed: "$(Package.Feed)"
               publish_symbols: true
               publish_public: "$(Package.Public)"
-              nuget_service_connection: "$(Package.nuget_service_connection)"
+              # Nuget
+              # nuget_service_connection: "$(Package.nuget_service_connection)"
+              nuget_service_connection: false
               # Secret Config
               cosmosdb_secret: false
               # .NET Core version variables

--- a/src/Amido.Stacks.Core.Tests/Amido.Stacks.Core.Tests.csproj
+++ b/src/Amido.Stacks.Core.Tests/Amido.Stacks.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -13,7 +13,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>	
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -23,5 +23,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Amido.Stacks.Core\Amido.Stacks.Core.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Amido.Stacks.Core.Tests/Amido.Stacks.Core.Tests.csproj
+++ b/src/Amido.Stacks.Core.Tests/Amido.Stacks.Core.Tests.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>	
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
### Update packages and the target environment for the test project.

#### 📲 What

Updating packages to their latest long term support release.  In this case, various testing packages used in the Amido.Stacks.Core.Tests project have been updated.  The target framework for the Amido.Stacks.Core.Tests has also been updated; previously it was net472;netcoreapp3.1 but it has been updated to net472;net6.0 because netcoreapp3.1 is no longer supported.

#### 🤔 Why

Package updates have been requested for .NET and Java Stacks as part of the latest Stacks cycle.

#### 🛠 How

Simple package updates and an update to the TargetFramework property in the in the Amido.Stacks.Core.Tests.csproj file.

#### 👀 Evidence

See the Amido.Stacks.Core.Tests.csproj file.

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?